### PR TITLE
Fix setting "MAXIMUM" mode format

### DIFF
--- a/actfw_core/capture.py
+++ b/actfw_core/capture.py
@@ -100,7 +100,7 @@ class V4LCameraCapture(Producer):
                 break
         if config is None:
             raise RuntimeError("expected capture format is unsupported")
-        fmt = self.video.set_format(config, width, height, expected_format)
+        fmt = self.video.set_format(config, expected_format=expected_format)
         self.capture_width, self.capture_height, self.capture_format = fmt
         self.video.set_framerate(config)
         # video.set_rotation(90)


### PR DESCRIPTION
Before this PR, If expected format is also supported, "MAXIMUM" format is not selected.
Example) A camera supports 2 formats [640x480, 1920x1080]. ("MAXIMUM" format is 1920x1080)
Expected format: 640x480 -> 640x480 is selected
Expected format: 480x480 -> 1920x1080 is selected
After this PR, 1920x1080 is selected in both cases.