### PR TITLE
refactor: Do not use `super(Klass, self).__init__()`

### DIFF
--- a/actfw_core/task/consumer.py
+++ b/actfw_core/task/consumer.py
@@ -6,7 +6,7 @@ class Consumer(Pipe):
     """Consumer Task."""
 
     def __init__(self):
-        super(Consumer, self).__init__()
+        super().__init__()
 
     def _add_out_queue(self, q):
         raise NotImplementedError("This is consumer")

--- a/actfw_core/task/isolated.py
+++ b/actfw_core/task/isolated.py
@@ -6,4 +6,4 @@ class Isolated(Task):
     """A task which has no connection."""
 
     def __init__(self):
-        super(Isolated, self).__init__()
+        super().__init__()

--- a/actfw_core/task/join.py
+++ b/actfw_core/task/join.py
@@ -20,7 +20,7 @@ class Join(Task, Generic[T_OUT, T_IN]):
 
     def __init__(self):
         """"""
-        super(Join, self).__init__()
+        super().__init__()
         self.running = True
         self.in_queues = []
         self.out_queues = []

--- a/actfw_core/task/pipe.py
+++ b/actfw_core/task/pipe.py
@@ -21,7 +21,7 @@ class Pipe(Task, Generic[T_OUT, T_IN]):
 
     def __init__(self):
         """"""
-        super(Pipe, self).__init__()
+        super().__init__()
         self.running = True
         self.in_queues = []
         self.out_queues = []

--- a/actfw_core/task/producer.py
+++ b/actfw_core/task/producer.py
@@ -7,7 +7,7 @@ class Producer(Pipe):
 
     def __init__(self):
         """"""
-        super(Producer, self).__init__()
+        super().__init__()
 
     def _add_in_queue(self, q):
         raise NotImplementedError("This is producer")

--- a/actfw_core/task/task.py
+++ b/actfw_core/task/task.py
@@ -7,4 +7,4 @@ class Task(Thread):
 
     def __init__(self):
         """"""
-        super(Task, self).__init__()
+        super().__init__()

--- a/actfw_core/task/tee.py
+++ b/actfw_core/task/tee.py
@@ -20,7 +20,7 @@ class Tee(Task):
 
     def __init__(self):
         """"""
-        super(Tee, self).__init__()
+        super().__init__()
         self.running = True
         self.in_queues = []
         self.out_queues = []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,7 +7,7 @@ from actfw_core.task import Consumer, Join, Pipe, Producer, Tee
 
 class Counter(Producer):
     def __init__(self):
-        super(Producer, self).__init__()
+        super().__init__()
         self.n = 0
 
     def proc(self, _):
@@ -19,7 +19,7 @@ class Counter(Producer):
 
 class Incrementer(Pipe):
     def __init__(self):
-        super(Incrementer, self).__init__()
+        super().__init__()
 
     def proc(self, x):
         return x + 1
@@ -27,7 +27,7 @@ class Incrementer(Pipe):
 
 class Adder(Pipe):
     def __init__(self):
-        super(Adder, self).__init__()
+        super().__init__()
 
     def proc(self, xs):
         return sum(xs)
@@ -35,7 +35,7 @@ class Adder(Pipe):
 
 class Logger(Consumer):
     def __init__(self):
-        super(Logger, self).__init__()
+        super().__init__()
         self.xs = []
 
     @property


### PR DESCRIPTION
https://docs.python.org/ja/3/library/functions.html#super

`super().__init__()` is equivalent to `super(ThisKlass, self).__init__()` and leads less mistakes, therefore recommended.