### PR TITLE
Refactor inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,8 @@
 - Stop exporting `actfw_core.__version__`.
 - (Breaking change; for actfw-* developers) Changed the types of `Pipe.in_queues` and `Pipe.out_queues`: `list[Queue[T]]` -> `list[_PadOut[T]]`/`list[_PadIn[T]]`.
 - (Breaking change; for actfw-* developers) Deleted the method `Frame._update()`.
-- (Breaking change; for actfw-* developers) Inheritance of `Task` classes are changed.  For example, `Consumer` and `Producer` were chirldren of `Pipe`, but they are not now.
+- (Breaking change; for actfw-* developers) Inheritance of `Task` classes are changed.
+  - All grandchildren of `Task` become direct children of it.
+  - `Consumer` and `Producer` were chirldren of `Pipe`, but they are not now.  They are children of `Task`.
+  - Use mixins and interfaces for implementation of children of `Task`.
+- Added methods `Task.stop()` and `Task.run()`.  (The later was a method of `Pipe`.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Stop exporting `actfw_core.__version__`.
 - (Breaking change; for actfw-* developers) Changed the types of `Pipe.in_queues` and `Pipe.out_queues`: `list[Queue[T]]` -> `list[_PadOut[T]]`/`list[_PadIn[T]]`.
 - (Breaking change; for actfw-* developers) Deleted the method `Frame._update()`.
+- (Breaking change; for actfw-* developers) Inheritance of `Task` classes are changed.  For example, `Consumer` and `Producer` were chirldren of `Pipe`, but they are not now.

--- a/actfw_core/task/consumer.py
+++ b/actfw_core/task/consumer.py
@@ -1,33 +1,57 @@
-from .pipe import Pipe
+import traceback
+from queue import Empty
+from typing import Generator, Generic, List, TypeVar
+
+from ..util.pad import _PadOut
+from .task import Task, _TaskI
+
+T_IN = TypeVar("T_IN")
 
 
-class Consumer(Pipe):
+class _ConsumerMixin(Generic[T_IN], _TaskI):
+    in_queues: List[_PadOut[T_IN]]
 
+    def __init__(self) -> None:
+        self.in_queues = []
+
+    def _add_in_queue(self, q: _PadOut[T_IN]) -> None:
+        self.in_queues.append(q)
+
+    def _inlet(self) -> Generator[T_IN, None, None]:
+        in_queue_id = 0
+        length = len(self.in_queues)
+        while self._is_running():
+            try:
+                i = self.in_queues[in_queue_id].get(timeout=1)
+                yield i
+                in_queue_id = (in_queue_id + 1) % length
+            except Empty:
+                pass
+            except GeneratorExit:
+                break
+            except:
+                traceback.print_exc()
+
+
+class Consumer(Generic[T_IN], Task, _ConsumerMixin[T_IN]):
     """Consumer Task."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self) -> None:
+        Task.__init__(self)
+        _ConsumerMixin.__init__(self)
 
-    def _add_out_queue(self, q):
-        raise NotImplementedError("This is consumer")
-
-    def _outlet(self, o):
-        raise NotImplementedError("This is consumer")
-
-    def run(self):
+    def run(self) -> None:
         """Run and start the activity"""
         for i in self._inlet():
             self.proc(i)
             if not self._is_running():
                 break
 
-    def connect(self, follow):
+    def proc(self, i: T_IN) -> None:
         """
-        Raises error
+        Pipeline Task Processor
 
         Args:
-            follow (:class:`~actfw_core.task.Task`): following task
+            i : task input
         """
-        if not issubclass(type(follow), Task):
-            raise TypeError("type(follow) must be a subclass of actfw_core.task.Task.")
-        raise NotImplementedError("This is consumer")
+        raise NotImplementedError("'proc' must be overridden.")

--- a/actfw_core/task/join.py
+++ b/actfw_core/task/join.py
@@ -1,7 +1,7 @@
 import traceback
 from queue import Empty, Full, Queue
 from threading import Thread
-from typing import Any, Generator, Generic, List, TypeVar
+from typing import Any, Generator, Generic, Tuple, TypeVar
 
 from ..util.pad import _PadBase, _PadBlocking, _PadIn, _PadOut
 from .consumer import _ConsumerMixin
@@ -9,7 +9,7 @@ from .producer import _ProducerMixin
 from .task import Task
 
 
-class Join(Task, _ProducerMixin[List[Any]], _ConsumerMixin[Any]):
+class Join(Task, _ProducerMixin[Tuple[Any, ...]], _ConsumerMixin[Any]):
     """Join Task."""
 
     def __init__(self) -> None:
@@ -18,7 +18,7 @@ class Join(Task, _ProducerMixin[List[Any]], _ConsumerMixin[Any]):
         _ProducerMixin.__init__(self)
         _ConsumerMixin.__init__(self)
 
-    def _inlet(self) -> Generator[List[Any], None, None]:
+    def _inlet(self) -> Generator[Tuple[Any, ...], None, None]:
         while self._is_running():
             try:
                 results = []
@@ -31,7 +31,7 @@ class Join(Task, _ProducerMixin[List[Any]], _ConsumerMixin[Any]):
                         except Empty:
                             pass
                 if len(self.in_queues) == len(results):
-                    yield results
+                    yield tuple(results)
                 else:
                     assert not self._is_running()
             except GeneratorExit:

--- a/actfw_core/task/join.py
+++ b/actfw_core/task/join.py
@@ -1,41 +1,24 @@
 import traceback
 from queue import Empty, Full, Queue
 from threading import Thread
-from typing import Generic, List, TypeVar
+from typing import Any, Generator, Generic, List, TypeVar
 
 from ..util.pad import _PadBase, _PadBlocking, _PadIn, _PadOut
+from .consumer import _ConsumerMixin
+from .producer import _ProducerMixin
 from .task import Task
 
-T_OUT = TypeVar("T_OUT")
-T_IN = TypeVar("T_IN")
 
-
-class Join(Task, Generic[T_OUT, T_IN]):
-    running: bool
-    in_queues: List[_PadOut[T_IN]]
-    out_queues: List[_PadIn[T_OUT]]
-    out_queue_id: int
-
+class Join(Task, _ProducerMixin[List[Any]], _ConsumerMixin[Any]):
     """Join Task."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """"""
-        super().__init__()
-        self.running = True
-        self.in_queues = []
-        self.out_queues = []
-        self.out_queue_id = 0
+        Task.__init__(self)
+        _ProducerMixin.__init__(self)
+        _ConsumerMixin.__init__(self)
 
-    def _is_running(self):
-        return self.running
-
-    def _add_in_queue(self, q):
-        self.in_queues.append(q)
-
-    def _add_out_queue(self, q):
-        self.out_queues.append(q)
-
-    def _inlet(self):
+    def _inlet(self) -> Generator[List[Any], None, None]:
         while self._is_running():
             try:
                 results = []
@@ -56,41 +39,10 @@ class Join(Task, Generic[T_OUT, T_IN]):
             except:
                 traceback.print_exc()
 
-    def _outlet(self, o):
-        length = len(self.out_queues)
-        while self._is_running():
-            try:
-                self.out_queues[self.out_queue_id].put(o, timeout=1)
-                self.out_queue_id = (self.out_queue_id + 1) % length
-                return True
-            except Full:
-                pass
-            except:
-                traceback.print_exc()
-        return False
-
-    def run(self):
+    def run(self) -> None:
         """Run and start the activity"""
         for i in self._inlet():
             o = i
             self._outlet(o)
             if not self._is_running():
                 break
-
-    def stop(self):
-        """Stop the activity"""
-        self.running = False
-
-    def connect(self, follow):
-        """
-        Connect following task.
-
-        Args:
-            follow (:class:`~actfw_core.task.Task`): following task
-        """
-        pad_out, pad_in = self._new_pad().into_pad_pair()
-        follow._add_in_queue(pad_out)
-        self._add_out_queue(pad_in)
-
-    def _new_pad(self) -> _PadBase[T_OUT]:
-        return _PadBlocking()

--- a/actfw_core/task/pipe.py
+++ b/actfw_core/task/pipe.py
@@ -1,70 +1,25 @@
 import inspect
-import traceback
-from queue import Empty, Full, Queue
-from threading import Thread
-from typing import Generic, List, TypeVar
+from typing import Generic, TypeVar
 
 from ..util.pad import _PadBase, _PadBlocking, _PadIn, _PadOut
+from .consumer import _ConsumerMixin
+from .producer import _ProducerMixin
 from .task import Task
 
 T_OUT = TypeVar("T_OUT")
 T_IN = TypeVar("T_IN")
 
 
-class Pipe(Task, Generic[T_OUT, T_IN]):
-    running: bool
-    in_queues: List[_PadOut[T_IN]]
-    out_queues: List[_PadIn[T_OUT]]
-    out_queue_id: int
-
+class Pipe(Generic[T_OUT, T_IN], Task, _ProducerMixin[T_OUT], _ConsumerMixin[T_IN]):
     """Straightforward Pipeline Task."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """"""
-        super().__init__()
-        self.running = True
-        self.in_queues = []
-        self.out_queues = []
-        self.out_queue_id = 0
+        Task.__init__(self)
+        _ProducerMixin.__init__(self)
+        _ConsumerMixin.__init__(self)
 
-    def _is_running(self):
-        return self.running
-
-    def _add_in_queue(self, q):
-        self.in_queues.append(q)
-
-    def _add_out_queue(self, q):
-        self.out_queues.append(q)
-
-    def _inlet(self):
-        in_queue_id = 0
-        length = len(self.in_queues)
-        while self._is_running():
-            try:
-                i = self.in_queues[in_queue_id].get(timeout=1)
-                yield i
-                in_queue_id = (in_queue_id + 1) % length
-            except Empty:
-                pass
-            except GeneratorExit:
-                break
-            except:
-                traceback.print_exc()
-
-    def _outlet(self, o):
-        length = len(self.out_queues)
-        while self._is_running():
-            try:
-                self.out_queues[self.out_queue_id].put(o, timeout=1)
-                self.out_queue_id = (self.out_queue_id + 1) % length
-                return True
-            except Full:
-                pass
-            except:
-                traceback.print_exc()
-        return False
-
-    def run(self):
+    def run(self) -> None:
         """Run and start the activity"""
         for i in self._inlet():
             o = self.proc(i)
@@ -72,29 +27,8 @@ class Pipe(Task, Generic[T_OUT, T_IN]):
             if not self._is_running():
                 break
 
-    def proc(self, i):
+    def proc(self, i: T_IN) -> T_OUT:
         """
         Pipeline Task Processor
-
-        Args:
-            i : task input
         """
         raise NotImplementedError("'proc' must be overridden.")
-
-    def stop(self):
-        """Stop the activity"""
-        self.running = False
-
-    def connect(self, follow):
-        """
-        Connect following task.
-
-        Args:
-            follow (:class:`~actfw_core.task.Task`): following task
-        """
-        pad_out, pad_in = self._new_pad().into_pad_pair()
-        follow._add_in_queue(pad_out)
-        self._add_out_queue(pad_in)
-
-    def _new_pad(self) -> _PadBase[T_OUT]:
-        return _PadBlocking()

--- a/actfw_core/task/producer.py
+++ b/actfw_core/task/producer.py
@@ -1,17 +1,71 @@
-from .pipe import Pipe
+import traceback
+from queue import Empty, Full
+from typing import Generic, List, TypeVar
+
+from ..util.pad import _PadBase, _PadBlocking, _PadIn
+from .consumer import _ConsumerMixin
+from .task import Task, _TaskI
+
+T_OUT = TypeVar("T_OUT")
 
 
-class Producer(Pipe):
+class _ProducerMixin(Generic[T_OUT], _TaskI):
+    out_queues: List[_PadIn[T_OUT]]
+    out_queue_id: int
 
+    def __init__(self) -> None:
+        """"""
+        self.out_queues = []
+        self.out_queue_id = 0
+
+    def _add_out_queue(self, q: _PadIn[T_OUT]) -> None:
+        self.out_queues.append(q)
+
+    def _new_pad(self) -> _PadBase[T_OUT]:
+        return _PadBlocking()
+
+    def connect(self, follow: _ConsumerMixin[T_OUT]) -> None:
+        """
+        Connect following task.
+        """
+        assert isinstance(follow, _ConsumerMixin)
+
+        pad_out, pad_in = self._new_pad().into_pad_pair()
+        follow._add_in_queue(pad_out)
+        self._add_out_queue(pad_in)
+
+    def _outlet(self, o: T_OUT) -> bool:
+        length = len(self.out_queues)
+        while self._is_running():
+            try:
+                self.out_queues[self.out_queue_id].put(o, timeout=1)
+                self.out_queue_id = (self.out_queue_id + 1) % length
+                return True
+            except Full:
+                pass
+            except:
+                traceback.print_exc()
+        return False
+
+
+class Producer(Generic[T_OUT], Task, _ProducerMixin[T_OUT]):
     """Producer Task."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """"""
-        super().__init__()
+        Task.__init__(self)
+        _ProducerMixin.__init__(self)
 
-    def _add_in_queue(self, q):
-        raise NotImplementedError("This is producer")
+    def run(self) -> None:
+        """Run and start the activity"""
+        while True:
+            o = self.proc()
+            self._outlet(o)
+            if not self._is_running():
+                break
 
-    def _inlet(self):
-        while self._is_running():
-            yield ()
+    def proc(self) -> T_OUT:
+        """
+        Pipeline Task Processor
+        """
+        raise NotImplementedError("'proc' must be overridden.")

--- a/actfw_core/task/task.py
+++ b/actfw_core/task/task.py
@@ -1,10 +1,31 @@
+from abc import ABC, abstractmethod
 from threading import Thread
 
 
-class Task(Thread):
+class _TaskI(ABC):
+    @abstractmethod
+    def _is_running(self) -> bool:
+        pass
+
+
+class Task(Thread, _TaskI):
+    running: bool
 
     """Actcast Application Task"""
 
     def __init__(self):
         """"""
-        super().__init__()
+        Thread.__init__(self)
+
+        self.running = True
+
+    def _is_running(self):
+        return self.running
+
+    def stop(self):
+        """Stop the activity"""
+        self.running = False
+
+    def run(self) -> None:
+        """Run and start the activity"""
+        raise NotImplementedError()

--- a/actfw_core/task/tee.py
+++ b/actfw_core/task/tee.py
@@ -1,56 +1,25 @@
 import traceback
 from queue import Empty, Full, Queue
-from threading import Thread
 from typing import Generic, List, TypeVar
 
-from ..util.pad import _PadBase, _PadBlocking, _PadIn, _PadOut
+from .consumer import _ConsumerMixin
+from .producer import _ProducerMixin
 from .task import Task
 
 T_OUT = TypeVar("T_OUT")
 T_IN = TypeVar("T_IN")
 
 
-class Tee(Task):
-    running: bool
-    in_queues: List[_PadOut[T_IN]]
-    out_queues: List[_PadIn[T_OUT]]
-    out_queue_id: int
-
+class Tee(Generic[T_OUT, T_IN], Task, _ProducerMixin[T_OUT], _ConsumerMixin[T_IN]):
     """Tee Task."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """"""
-        super().__init__()
-        self.running = True
-        self.in_queues = []
-        self.out_queues = []
-        self.out_queue_id = 0
+        Task.__init__(self)
+        _ProducerMixin.__init__(self)
+        _ConsumerMixin.__init__(self)
 
-    def _is_running(self):
-        return self.running
-
-    def _add_in_queue(self, q):
-        self.in_queues.append(q)
-
-    def _add_out_queue(self, q):
-        self.out_queues.append(q)
-
-    def _inlet(self):
-        in_queue_id = 0
-        length = len(self.in_queues)
-        while self._is_running():
-            try:
-                i = self.in_queues[in_queue_id].get(timeout=1)
-                yield i
-                in_queue_id = (in_queue_id + 1) % length
-            except Empty:
-                pass
-            except GeneratorExit:
-                break
-            except:
-                traceback.print_exc()
-
-    def _outlet(self, o):
+    def _outlet(self, o: T_OUT) -> None:
         while self._is_running():
             for out_queue in self.out_queues:
                 try:
@@ -62,28 +31,10 @@ class Tee(Task):
             return True
         return False
 
-    def run(self):
+    def run(self) -> None:
         """Run and start the activity"""
         for i in self._inlet():
             o = i
             self._outlet(o)
             if not self._is_running():
                 break
-
-    def stop(self):
-        """Stop the activity"""
-        self.running = False
-
-    def connect(self, follow):
-        """
-        Connect following task.
-
-        Args:
-            follow (:class:`~actfw_core.task.Task`): following task
-        """
-        pad_out, pad_in = self._new_pad().into_pad_pair()
-        follow._add_in_queue(pad_out)
-        self._add_out_queue(pad_in)
-
-    def _new_pad(self) -> _PadBase[T_OUT]:
-        return _PadBlocking()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,7 +10,7 @@ class Counter(Producer):
         super().__init__()
         self.n = 0
 
-    def proc(self, _):
+    def proc(self):
         time.sleep(0.01)
         n = self.n
         self.n += 1


### PR DESCRIPTION
Review it carefully, please.

- Fixed incorrect usage of inheritance.  Use mixins and interfaces.
- I think it is safe even if children of these classes (in the user's code) use internal methods or properties. So, property names e.g. `out_queues` are unchanged at this timing. (It should be `_out_queues`.) We'll postpone this change to major version 3.
- Added type hints.
- Changed type of output of `Join`, because the output is not uniform. 3d8d9ff `Tuple` is better than `List` I think.
