### PR TITLE
refactor: Do not catch errors unreasonably

### DIFF
--- a/actfw_core/capture.py
+++ b/actfw_core/capture.py
@@ -1,5 +1,4 @@
 import enum
-import traceback
 from queue import Full
 
 from actfw_core.v4l2.video import V4L2_PIX_FMT, Video, VideoPort
@@ -157,8 +156,6 @@ class V4LCameraCapture(Producer):
                 return True
             except Full:
                 return False
-            except:
-                traceback.print_exc()
         return False
 
     def _new_pad(self):  # -> _PadBase[T_OUT]

--- a/actfw_core/command_server.py
+++ b/actfw_core/command_server.py
@@ -2,7 +2,6 @@ import base64
 import io
 import os
 import socket
-import traceback
 from threading import Lock
 
 from .task import Isolated
@@ -93,8 +92,6 @@ class CommandServer(Isolated):
                 conn.close()
             except socket.timeout:
                 pass
-            except Exception as e:
-                traceback.print_exc()
         os.remove(self.sock_path)
 
     def update_image(self, image):

--- a/actfw_core/task/consumer.py
+++ b/actfw_core/task/consumer.py
@@ -1,4 +1,3 @@
-import traceback
 from queue import Empty
 from typing import Generator, Generic, List, TypeVar
 
@@ -29,8 +28,6 @@ class _ConsumerMixin(Generic[T_IN], _TaskI):
                 pass
             except GeneratorExit:
                 break
-            except:
-                traceback.print_exc()
 
 
 class Consumer(Generic[T_IN], Task, _ConsumerMixin[T_IN]):

--- a/actfw_core/task/join.py
+++ b/actfw_core/task/join.py
@@ -1,4 +1,3 @@
-import traceback
 from queue import Empty, Full, Queue
 from threading import Thread
 from typing import Any, Generator, Generic, Tuple, TypeVar
@@ -36,8 +35,6 @@ class Join(Task, _ProducerMixin[Tuple[Any, ...]], _ConsumerMixin[Any]):
                     assert not self._is_running()
             except GeneratorExit:
                 break
-            except:
-                traceback.print_exc()
 
     def run(self) -> None:
         """Run and start the activity"""

--- a/actfw_core/task/producer.py
+++ b/actfw_core/task/producer.py
@@ -1,4 +1,3 @@
-import traceback
 from queue import Empty, Full
 from typing import Generic, List, TypeVar
 
@@ -43,8 +42,6 @@ class _ProducerMixin(Generic[T_OUT], _TaskI):
                 return True
             except Full:
                 pass
-            except:
-                traceback.print_exc()
         return False
 
 

--- a/actfw_core/task/tee.py
+++ b/actfw_core/task/tee.py
@@ -1,4 +1,3 @@
-import traceback
 from queue import Empty, Full, Queue
 from typing import Generic, List, TypeVar
 
@@ -26,8 +25,6 @@ class Tee(Generic[T_OUT, T_IN], Task, _ProducerMixin[T_OUT], _ConsumerMixin[T_IN
                     out_queue.put(o, timeout=1)
                 except Full:
                     pass
-                except:
-                    traceback.print_exc()
             return True
         return False
 


### PR DESCRIPTION
Delete "catch and forgot errors" patterns.
We can still get backtraces because python shows them by default when an error reaches thread root.