### PR TITLE
fix: `Producer._outlet()` mustn't block and must return control.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
   - Use mixins and interfaces for implementation of children of `Task`.
 - Added methods `Task.stop()` and `Task.run()`.  (The later was a method of `Pipe`.)
 - Added type annotations.
+- (Breaking change; for actfw-* developers) Modified the behavior of `Producer._outlet()`; made it non-blocking and return false if the `_PadOut` is full.

--- a/actfw_core/task/producer.py
+++ b/actfw_core/task/producer.py
@@ -35,14 +35,15 @@ class _ProducerMixin(Generic[T_OUT], _TaskI):
 
     def _outlet(self, o: T_OUT) -> bool:
         length = len(self.out_queues)
-        while self._is_running():
+        if self._is_running():
             try:
                 self.out_queues[self.out_queue_id].put(o, timeout=1)
                 self.out_queue_id = (self.out_queue_id + 1) % length
                 return True
             except Full:
-                pass
-        return False
+                return False
+        else:
+            return False
 
 
 class Producer(Generic[T_OUT], Task, _ProducerMixin[T_OUT]):


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

In `actfw-core` 1.5.2 and `actfw-raspberrypi` 1.4.0,

- `Producer._outlet()` does block.
- `V4LCameraCapture._outlet()` does not block.
- `PiCameraCapture._outlet()` does not block.

We believe that the main loop of `Task.run()` should have control periodically.
So, we use the "not blocking" behavior.


