### PR TITLE
fix type definition

### DIFF
--- a/actfw_core/v4l2/types.py
+++ b/actfw_core/v4l2/types.py
@@ -344,6 +344,13 @@ class _m_for_buffer(Union):
     ]
 
 
+class _fd_or_reserved(Union):
+    _fields_ = [
+        ("request_fd", c_int32),
+        ("reserved", c_uint32),
+    ]
+
+
 class buffer(Structure):
     _fields_ = [
         ("index", c_uint32),
@@ -358,6 +365,5 @@ class buffer(Structure):
         ("m", _m_for_buffer),
         ("length", c_uint32),
         ("reserved2", c_uint32),
-        ("reserved", c_uint32),  # In fact, `reserved` is the union of s32 and u32
-                                 # https://github.com/torvalds/linux/blob/master/include/uapi/linux/videodev2.h#L1061-L1064
+        ("reserved", _fd_or_reserved),
     ]

--- a/actfw_core/v4l2/types.py
+++ b/actfw_core/v4l2/types.py
@@ -198,7 +198,7 @@ class sdr_format(Structure):
     _fields_ = [
         ("pixelformat", c_uint32),
         ("buffersize", c_uint32),
-        ("reserved", c_ubyte * 24),
+        ("reserved", c_uint8 * 24),
     ]
 
 

--- a/actfw_core/v4l2/types.py
+++ b/actfw_core/v4l2/types.py
@@ -357,6 +357,7 @@ class buffer(Structure):
         ("memory", c_uint32),
         ("m", _m_for_buffer),
         ("length", c_uint32),
-        ("reserved2", c_uint),
-        ("reserved", c_uint),
+        ("reserved2", c_uint32),
+        ("reserved", c_uint32),  # In fact, `reserved` is the union of s32 and u32
+                                 # https://github.com/torvalds/linux/blob/master/include/uapi/linux/videodev2.h#L1061-L1064
     ]

--- a/actfw_core/v4l2/types.py
+++ b/actfw_core/v4l2/types.py
@@ -5,42 +5,42 @@ from ctypes import *
 
 class capability(Structure):
     _fields_ = [
-        ("driver", c_ubyte * 16),
-        ("card", c_ubyte * 32),
-        ("bus_info", c_ubyte * 32),
-        ("version", c_uint),
-        ("capabilities", c_uint),
-        ("device_caps", c_uint),
-        ("reserved", c_uint * 3),
+        ("driver", c_uint8 * 16),
+        ("card", c_uint8 * 32),
+        ("bus_info", c_uint8 * 32),
+        ("version", c_uint32),
+        ("capabilities", c_uint32),
+        ("device_caps", c_uint32),
+        ("reserved", c_uint32 * 3),
     ]
 
 
 class fmtdesc(Structure):
     _fields_ = [
-        ("index", c_uint),
-        ("type", c_uint),
-        ("flags", c_uint),
-        ("description", c_ubyte * 32),
-        ("pixelformat", c_uint),
-        ("reserved", c_uint * 4),
+        ("index", c_uint32),
+        ("type", c_uint32),
+        ("flags", c_uint32),
+        ("description", c_uint8 * 32),
+        ("pixelformat", c_uint32),
+        ("reserved", c_uint32 * 4),
     ]
 
 
 class frmsize_discrete(Structure):
     _fields_ = [
-        ("width", c_uint),
-        ("height", c_uint),
+        ("width", c_uint32),
+        ("height", c_uint32),
     ]
 
 
 class frmsize_stepwise(Structure):
     _fields_ = [
-        ("min_width", c_uint),
-        ("max_width", c_uint),
-        ("step_width", c_uint),
-        ("min_height", c_uint),
-        ("max_height", c_uint),
-        ("step_height", c_uint),
+        ("min_width", c_uint32),
+        ("max_width", c_uint32),
+        ("step_width", c_uint32),
+        ("min_height", c_uint32),
+        ("max_height", c_uint32),
+        ("step_height", c_uint32),
     ]
 
 
@@ -54,18 +54,18 @@ class _frmsize_for_frmsizeenum(Union):
 class frmsizeenum(Structure):
     _anonymous_ = ("_frmsize",)
     _fields_ = [
-        ("index", c_uint),
-        ("pixel_format", c_uint),
-        ("type", c_uint),
+        ("index", c_uint32),
+        ("pixel_format", c_uint32),
+        ("type", c_uint32),
         ("_frmsize", _frmsize_for_frmsizeenum),
-        ("reserved", c_uint * 2),
+        ("reserved", c_uint32 * 2),
     ]
 
 
 class fract(Structure):
     _fields_ = [
-        ("numerator", c_uint),
-        ("denominator", c_uint),
+        ("numerator", c_uint32),
+        ("denominator", c_uint32),
     ]
 
 
@@ -87,64 +87,66 @@ class _frmival_for_frmivalenum(Union):
 class frmivalenum(Structure):
     _anonymous_ = ("_frmival",)
     _fields_ = [
-        ("index", c_uint),
-        ("pixel_format", c_uint),
-        ("width", c_uint),
-        ("height", c_uint),
-        ("type", c_uint),
+        ("index", c_uint32),
+        ("pixel_format", c_uint32),
+        ("width", c_uint32),
+        ("height", c_uint32),
+        ("type", c_uint32),
         ("_frmival", _frmival_for_frmivalenum),
-        ("reserved", c_uint * 2),
+        ("reserved", c_uint32 * 2),
     ]
 
 
 class pix_format(Structure):
     _fields_ = [
-        ("width", c_uint),
-        ("height", c_uint),
-        ("pixelformat", c_uint),
-        ("field", c_uint),
-        ("bytesperline", c_uint),
-        ("sizeimage", c_uint),
-        ("colorspace", c_uint),
-        ("priv", c_uint),
-        ("flags", c_uint),
-        ("ycbcr_enc", c_uint),
-        ("quantization", c_uint),
-        ("xfer_func", c_uint),
+        ("width", c_uint32),
+        ("height", c_uint32),
+        ("pixelformat", c_uint32),
+        ("field", c_uint32),
+        ("bytesperline", c_uint32),
+        ("sizeimage", c_uint32),
+        ("colorspace", c_uint32),
+        ("priv", c_uint32),
+        ("flags", c_uint32),
+        ("ycbcr_enc", c_uint32),
+        ("quantization", c_uint32),
+        ("xfer_func", c_uint32),
     ]
 
 
 class plane_pix_format(Structure):
+    _pack_ = 1
     _fields_ = [
-        ("sizeimage", c_uint),
-        ("bytesperline", c_uint),
-        ("reserved", c_ushort * 6),
+        ("sizeimage", c_uint32),
+        ("bytesperline", c_uint32),
+        ("reserved", c_uint16 * 6),
     ]
 
 
 class pix_format_mplane(Structure):
+    _pack_ = 1
     _fields_ = [
-        ("width", c_uint),
-        ("height", c_uint),
-        ("pixelformat", c_uint),
-        ("field", c_uint),
-        ("colorspace", c_uint),
+        ("width", c_uint32),
+        ("height", c_uint32),
+        ("pixelformat", c_uint32),
+        ("field", c_uint32),
+        ("colorspace", c_uint32),
         ("plane_fmt", plane_pix_format * 8),  # VIDEO_MAX_PLANES
-        ("num_planes", c_ubyte),
-        ("flags", c_ubyte),
-        ("ycbcr_enc", c_ubyte),
-        ("quantization", c_ubyte),
-        ("xfer_func", c_ubyte),
-        ("reserved", c_ubyte * 7),
+        ("num_planes", c_uint8),
+        ("flags", c_uint8),
+        ("ycbcr_enc", c_uint8),
+        ("quantization", c_uint8),
+        ("xfer_func", c_uint8),
+        ("reserved", c_uint8 * 7),
     ]
 
 
 class rect(Structure):
     _fields_ = [
-        ("left", c_int),
-        ("top", c_int),
-        ("width", c_uint),
-        ("height", c_uint),
+        ("left", c_int32),
+        ("top", c_int32),
+        ("width", c_uint32),
+        ("height", c_uint32),
     ]
 
 
@@ -161,25 +163,25 @@ clip._fields_ = [
 class window(Structure):
     _fields_ = [
         ("w", rect),
-        ("field", c_uint),
-        ("chromakey", c_uint),
+        ("field", c_uint32),
+        ("chromakey", c_uint32),
         ("clips", POINTER(clip)),
-        ("clipcount", c_uint),
+        ("clipcount", c_uint32),
         ("bitmap", c_void_p),
-        ("global_alpha", c_ubyte),
+        ("global_alpha", c_uint8),
     ]
 
 
 class vbi_format(Structure):
     _fields_ = [
-        ("sampling_rate", c_uint),
-        ("offset", c_uint),
-        ("samples_per_line", c_uint),
-        ("sample_format", c_uint),
-        ("start", c_int * 2),
-        ("count", c_uint * 2),
-        ("flags", c_uint),
-        ("reserved", c_uint * 2),
+        ("sampling_rate", c_uint32),
+        ("offset", c_uint32),
+        ("samples_per_line", c_uint32),
+        ("sample_format", c_uint32),
+        ("start", c_int32 * 2),
+        ("count", c_uint32 * 2),
+        ("flags", c_uint32),
+        ("reserved", c_uint32 * 2),
     ]
 
 
@@ -192,10 +194,19 @@ class sliced_vbi_format(Structure):
 
 
 class sdr_format(Structure):
+    _pack_ = 1
     _fields_ = [
-        ("pixelformat", c_uint),
-        ("buffersize", c_uint),
+        ("pixelformat", c_uint32),
+        ("buffersize", c_uint32),
         ("reserved", c_ubyte * 24),
+    ]
+
+
+class meta_format(Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("pixelformat", c_uint32),
+        ("buffersize", c_uint32),
     ]
 
 
@@ -207,36 +218,37 @@ class _fmt_for_format(Union):
         ("vbi", vbi_format),
         ("sliced", sliced_vbi_format),
         ("sdr", sdr_format),
-        ("raw_data", c_ubyte * 200),
+        ("meta", meta_format),
+        ("raw_data", c_uint8 * 200),
     ]
 
 
 class format(Structure):
     _fields_ = [
-        ("type", c_uint),
+        ("type", c_uint32),
         ("fmt", _fmt_for_format),
     ]
 
 
 class captureparm(Structure):
     _fields_ = [
-        ("capability", c_uint),
-        ("capturemode", c_uint),
+        ("capability", c_uint32),
+        ("capturemode", c_uint32),
         ("timeperframe", fract),
-        ("extendedmode", c_uint),
-        ("readbufferbs", c_uint),
-        ("reserved", c_uint * 4),
+        ("extendedmode", c_uint32),
+        ("readbufferbs", c_uint32),
+        ("reserved", c_uint32 * 4),
     ]
 
 
 class outputparm(Structure):
     _fields_ = [
-        ("capability", c_uint),
-        ("outputmode", c_uint),
+        ("capability", c_uint32),
+        ("outputmode", c_uint32),
         ("timeperframe", fract),
-        ("extendedmode", c_uint),
-        ("writebuffers", c_uint),
-        ("reserved", c_uint * 4),
+        ("extendedmode", c_uint32),
+        ("writebuffers", c_uint32),
+        ("reserved", c_uint32 * 4),
     ]
 
 
@@ -244,48 +256,49 @@ class _parm_for_streamparm(Union):
     _fields_ = [
         ("capture", captureparm),
         ("output", outputparm),
-        ("raw_data", c_ubyte * 200),
+        ("raw_data", c_uint8 * 200),
     ]
 
 
 class streamparm(Structure):
     _fields_ = [
-        ("type", c_uint),
+        ("type", c_uint32),
         ("parm", _parm_for_streamparm),
     ]
 
 
 class control(Structure):
     _fields_ = [
-        ("id", c_uint),
-        ("value", c_int),
+        ("id", c_uint32),
+        ("value", c_int32),
     ]
 
 
 class queryctrl(Structure):
     _fields_ = [
-        ("id", c_uint),
-        ("type", c_uint),
-        ("name", c_ubyte * 32),
-        ("minimum", c_int),
-        ("maximum", c_int),
-        ("step", c_int),
-        ("default_value", c_int),
-        ("flags", c_uint),
-        ("reserved", c_uint * 2),
+        ("id", c_uint32),
+        ("type", c_uint32),
+        ("name", c_uint8 * 32),
+        ("minimum", c_int32),
+        ("maximum", c_int32),
+        ("step", c_int32),
+        ("default_value", c_int32),
+        ("flags", c_uint32),
+        ("reserved", c_uint32 * 2),
     ]
 
 
 class requestbuffers(Structure):
     _fields_ = [
-        ("count", c_uint),
-        ("type", c_uint),
-        ("memory", c_uint),
-        ("reserved", c_uint * 2),
+        ("count", c_uint32),
+        ("type", c_uint32),
+        ("memory", c_uint32),
+        ("reserved", c_uint32 * 2),
     ]
 
 
 class timeval(Structure):
+    # TODO: check
     _fields_ = [
         ("sec", c_long),
         ("usec", c_long),
@@ -294,56 +307,56 @@ class timeval(Structure):
 
 class timecode(Structure):
     _fields_ = [
-        ("type", c_uint),
-        ("flags", c_uint),
-        ("frames", c_ubyte),
-        ("seconds", c_ubyte),
-        ("minutes", c_ubyte),
-        ("hours", c_ubyte),
-        ("userbits", c_ubyte * 4),
+        ("type", c_uint32),
+        ("flags", c_uint32),
+        ("frames", c_uint8),
+        ("seconds", c_uint8),
+        ("minutes", c_uint8),
+        ("hours", c_uint8),
+        ("userbits", c_uint8 * 4),
     ]
 
 
 class _m_for_plane(Union):
     _fields_ = [
-        ("mem_offset", c_uint),
+        ("mem_offset", c_uint32),
         ("userptr", c_ulong),
-        ("fd", c_int),
+        ("fd", c_int32),
     ]
 
 
 class plane(Structure):
     _fields_ = [
-        ("bytesused", c_uint),
-        ("length", c_uint),
+        ("bytesused", c_uint32),
+        ("length", c_uint32),
         ("m", _m_for_plane),
-        ("data_offset", c_uint),
-        ("reserved", c_uint * 11),
+        ("data_offset", c_uint32),
+        ("reserved", c_uint32 * 11),
     ]
 
 
 class _m_for_buffer(Union):
     _fields_ = [
-        ("offset", c_uint),
+        ("offset", c_uint32),
         ("userptr", c_ulong),
         ("planes", POINTER(plane)),
-        ("fd", c_int),
+        ("fd", c_int32),
     ]
 
 
 class buffer(Structure):
     _fields_ = [
-        ("index", c_uint),
-        ("type", c_uint),
-        ("bytesused", c_uint),
-        ("flags", c_uint),
-        ("field", c_uint),
+        ("index", c_uint32),
+        ("type", c_uint32),
+        ("bytesused", c_uint32),
+        ("flags", c_uint32),
+        ("field", c_uint32),
         ("timestamp", timeval),
         ("timecode", timecode),
-        ("sequence", c_uint),
-        ("memory", c_uint),
+        ("sequence", c_uint32),
+        ("memory", c_uint32),
         ("m", _m_for_buffer),
-        ("length", c_uint),
+        ("length", c_uint32),
         ("reserved2", c_uint),
         ("reserved", c_uint),
     ]


### PR DESCRIPTION
## Check list

- [ ] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

The type definition for v4l2 need to be fixed:

- lack of size specification
  - fixed size types in [the original header file](https://github.com/torvalds/linux/blob/master/include/uapi/linux/videodev2.h) are used
- `meta_format` in `_fmt_for_format` is lacking
  -  https://github.com/Idein/actfw-core/blob/f805469a214d32e5ad17ba58903e5931668a5ad2/actfw_core/v4l2/types.py#L202
  - https://github.com/torvalds/linux/blob/master/include/uapi/linux/videodev2.h#L2333
- Some structures are defined with `__attribute__ ((packed))`. 
  - Need to add `_pack_ = 1` 
  - https://docs.python.org/3/library/ctypes.html#ctypes.Structure._pack_