### PR TITLE
Mmap once

### DIFF
--- a/actfw_core/capture.py
+++ b/actfw_core/capture.py
@@ -121,9 +121,8 @@ class V4LCameraCapture(Producer[Frame[bytes]]):
         # assert type(self.capture_format) is V4L2_PIX_FMT
         self.video.set_framerate(config)
         # video.set_rotation(90)
-        buffers = self.video.request_buffers(4)
-        for buf in buffers:
-            self.video.queue_buffer(buf)
+        self.video.request_buffers(4)
+        self.video.queue_buffer()
 
     def capture_size(self) -> Tuple[int, int]:
         """

--- a/actfw_core/v4l2/video.py
+++ b/actfw_core/v4l2/video.py
@@ -24,7 +24,7 @@ class _libv4l2(object):
 
             # ioctl
             self.lib.v4l2_ioctl.argtypes = [c_int, c_ulong, c_void_p]
-            self.lib.v4l2_ioctl.rettype = c_int
+            self.lib.v4l2_ioctl.restype = c_int
 
             # mmap
             self.lib.v4l2_mmap.argtypes = [
@@ -35,11 +35,11 @@ class _libv4l2(object):
                 c_int,
                 c_int64,
             ]
-            self.lib.v4l2_mmap.rettype = c_void_p
+            self.lib.v4l2_mmap.restype = c_void_p
 
             # munmap
             self.lib.v4l2_munmap.argtypes = [c_void_p, c_size_t]
-            self.lib.v4l2_munmap.rettype = c_int
+            self.lib.v4l2_munmap.restype = c_int
 
     def ioctl(self, *args, **kwargs):
         if self.lib is None:
@@ -66,7 +66,7 @@ class _libv4lconvert(object):
 
             # create
             self.lib.v4lconvert_create.argtypes = [c_int]
-            self.lib.v4lconvert_create.rettype = c_void_p  # struct v4lconvert_data *
+            self.lib.v4lconvert_create.restype = c_void_p  # struct v4lconvert_data *
 
             # convert
             self.lib.v4lconvert_convert.argtypes = [
@@ -78,11 +78,11 @@ class _libv4lconvert(object):
                 POINTER(c_ubyte),
                 c_int,
             ]
-            self.lib.v4lconvert_convert.rettype = c_void_p  # struct v4lconvert_data *
+            self.lib.v4lconvert_convert.restype = c_void_p  # struct v4lconvert_data *
 
             # try_format
             self.lib.v4lconvert_try_format.argtypes = [c_void_p, POINTER(format), POINTER(format)]
-            self.lib.v4lconvert_try_format.rettype = c_int
+            self.lib.v4lconvert_try_format.restype = c_int
 
     def create(self, *args, **kwargs):
         if self.lib is None:

--- a/actfw_core/v4l2/video.py
+++ b/actfw_core/v4l2/video.py
@@ -22,6 +22,18 @@ class _libv4l2(object):
         if path is not None:
             self.lib = CDLL(path, use_errno=True)
 
+            # ioctl
+            self.lib.v4l2_ioctl.argtypes = [c_int, c_ulong, c_void_p]
+            self.lib.v4l2_ioctl.rettype = c_int
+
+            # mmap
+            self.lib.v4l2_mmap.argtypes = [c_void_p, c_size_t, c_int, c_int, c_int, c_int64]
+            self.lib.v4l2_mmap.rettype = c_void_p
+
+            # munmap
+            self.lib.v4l2_munmap.argtypes = [c_void_p, c_size_t]
+            self.lib.v4l2_munmap.rettype = c_int
+
     def ioctl(self, *args, **kwargs):
         if self.lib is None:
             raise FileNotFoundError("Not found: 'libv4l2.so'")
@@ -44,6 +56,19 @@ class _libv4lconvert(object):
         path = find_library("v4lconvert")
         if path is not None:
             self.lib = CDLL(path, use_errno=True)
+
+            # create
+            self.lib.v4lconvert_create.argtypes = [c_int]
+            self.lib.v4lconvert_create.rettype = c_void_p  # struct v4lconvert_data *
+
+            # convert
+            self.lib.v4lconvert_convert.argtypes = [c_void_p, POINTER(format), POINTER(format),
+                                                    POINTER(c_ubyte), c_int, POINTER(c_ubyte), c_int]
+            self.lib.v4lconvert_convert.rettype = c_void_p  # struct v4lconvert_data *
+
+            # try_format
+            self.lib.v4lconvert_try_format.argtypes = [c_void_p, POINTER(format), POINTER(format)]
+            self.lib.v4lconvert_try_format.rettype = c_int
 
     def create(self, *args, **kwargs):
         if self.lib is None:
@@ -887,7 +912,7 @@ class VideoBuffer(object):
 
         self.video = video
         self.buf = buf
-        self.mapped_buf = cast(result, POINTER(ARRAY(c_uint8, self.buf.length)))
+        self.mapped_buf = cast(result, POINTER(c_uint8))
 
     def unmap_buffer(self):
         if self.mapped_buf is None:

--- a/actfw_core/v4l2/video.py
+++ b/actfw_core/v4l2/video.py
@@ -904,7 +904,7 @@ class VideoStream(object):
                 byref(self.video.expected_fmt),
                 buf.mapped_buf,
                 self.video.fmt.fmt.pix.sizeimage,
-                dst,
+                cast(dst, POINTER(c_ubyte)),
                 self.video.expected_fmt.fmt.pix.sizeimage,
             )
         else:

--- a/actfw_core/v4l2/video.py
+++ b/actfw_core/v4l2/video.py
@@ -27,7 +27,14 @@ class _libv4l2(object):
             self.lib.v4l2_ioctl.rettype = c_int
 
             # mmap
-            self.lib.v4l2_mmap.argtypes = [c_void_p, c_size_t, c_int, c_int, c_int, c_int64]
+            self.lib.v4l2_mmap.argtypes = [
+                c_void_p,
+                c_size_t,
+                c_int,
+                c_int,
+                c_int,
+                c_int64,
+            ]
             self.lib.v4l2_mmap.rettype = c_void_p
 
             # munmap
@@ -62,8 +69,15 @@ class _libv4lconvert(object):
             self.lib.v4lconvert_create.rettype = c_void_p  # struct v4lconvert_data *
 
             # convert
-            self.lib.v4lconvert_convert.argtypes = [c_void_p, POINTER(format), POINTER(format),
-                                                    POINTER(c_ubyte), c_int, POINTER(c_ubyte), c_int]
+            self.lib.v4lconvert_convert.argtypes = [
+                c_void_p,
+                POINTER(format),
+                POINTER(format),
+                POINTER(c_ubyte),
+                c_int,
+                POINTER(c_ubyte),
+                c_int,
+            ]
             self.lib.v4lconvert_convert.rettype = c_void_p  # struct v4lconvert_data *
 
             # try_format
@@ -560,7 +574,15 @@ class Video(object):
                     if expected_format == pixel_format:
                         results.append(candidate)
                     else:
-                        if self.try_convert(candidate, candidate.width, candidate.height, expected_format) is not None:
+                        if (
+                            self.try_convert(
+                                candidate,
+                                candidate.width,
+                                candidate.height,
+                                expected_format,
+                            )
+                            is not None
+                        ):
                             results.append(candidate)
 
                     old_candidate = candidate
@@ -592,7 +614,11 @@ class Video(object):
             raise RuntimeError("incompatible format")
 
         before = (expected_width, expected_height, expected_format)
-        after = (expected_fmt.fmt.pix.width, expected_fmt.fmt.pix.height, expected_fmt.fmt.pix.pixelformat)
+        after = (
+            expected_fmt.fmt.pix.width,
+            expected_fmt.fmt.pix.height,
+            expected_fmt.fmt.pix.pixelformat,
+        )
 
         if before == after:
             return (fmt, expected_fmt)
@@ -619,7 +645,11 @@ class Video(object):
         if -1 == result:
             raise RuntimeError("ioctl(VIDIOC_S_FMT)")
 
-        return (self.expected_fmt.fmt.pix.width, self.expected_fmt.fmt.pix.height, self.expected_fmt.fmt.pix.pixelformat)
+        return (
+            self.expected_fmt.fmt.pix.width,
+            self.expected_fmt.fmt.pix.height,
+            self.expected_fmt.fmt.pix.pixelformat,
+        )
 
     def set_framerate(self, conf):
 

--- a/actfw_core/v4l2/video.py
+++ b/actfw_core/v4l2/video.py
@@ -896,7 +896,7 @@ class VideoStream(object):
     def capture(self, timeout=1, in_expected_format=True):
 
         buf = self.video.dequeue_buffer(timeout=timeout)
-        dst = (c_uint8 * self.video.expected_fmt.fmt.pix.sizeimage)()
+        dst = bytes(self.video.expected_fmt.fmt.pix.sizeimage)
         if in_expected_format:
             _v4lconvert.convert(
                 self.video.converter,


### PR DESCRIPTION
## Check list

- [ ] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

This PR reduce the number of calls of `v4l2_mmap` and `v4l2_munmap`.
In current implementation, `VideoStream.capture` calls `v4l2_mmap` and `v4l2_munmap` for every time.
It is unnecessary because the memory from `v4l2_mmap` is automatically written by each dequeue.


