### PR TITLE
fix: `CommandServer` failed to response to Take Photo command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1 (2021-09-01)
+
+- Fixed a bug: In 2.1.0, `actfw_core.CommandServer` failed to response to Take Photo command.
+
 ## 2.1.0 (2021-08-30)
 
 - Support a new actcast agent feature by `actfw_core.ServiceClient`.

--- a/actfw_core/command_server.py
+++ b/actfw_core/command_server.py
@@ -73,12 +73,13 @@ class CommandServer(Isolated):
                     continue
 
                 if request.kind == CommandKind.TAKE_PHOTO:
-                    header = "data:image/png;base64,"
+                    header = b"data:image/png;base64,"
                     with self.img_lock:
                         pngimg = io.BytesIO()
                         self.img.save(pngimg, format="PNG")
                         b64img = base64.b64encode(pngimg.getbuffer())
-                    response = CommandResponse(copy.copy(request.id_), Status.GENERAL_ERROR, header + b64img.decode("utf-8"))
+                    data = header + b64img
+                    response = CommandResponse(copy.copy(request.id_), Status.OK, data)
                 else:
                     response = CommandResponse(
                         copy.copy(request.id_),
@@ -86,6 +87,7 @@ class CommandServer(Isolated):
                         b"",
                     )
                 conn.sendall(response.to_bytes())
+                conn.shutdown(socket.SHUT_RDWR)
                 conn.close()
             except socket.timeout:
                 pass


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

Fixed a bug I introduced in https://github.com/Idein/actfw-core/pull/42 .

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "./python/site-packages/actfw_core/command_server.py", line 88, in run
    conn.sendall(response.to_bytes())
  File "./python/site-packages/actfw_core/_private/schema/agent_app_protocol.py", line 92, in to_bytes
    return f"{id_} {status} {len(data)} ".encode() + data
TypeError: can't concat str to bytes
```