### PR TITLE
fix assertion error when the CommandServer is terminating without calling `cmd.update_image()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## xxxx
+
+- Fix a bug: actfw doesn't raise assertion error when it is stopped before `update_image` is called.
+
 ## 2.2.0a0 (2022-03-14)
 
 - upgrade pillow version for python>=3.8 environment

--- a/actfw_core/command_server.py
+++ b/actfw_core/command_server.py
@@ -59,7 +59,10 @@ class CommandServer(Isolated):
                     else:
                         break
             try:
-                assert self.img is not None
+                if self.img is None:
+                    # this server may be terminating
+                    # re-check self.running
+                    continue
 
                 conn, _ = s.accept()
                 request, err = CommandRequest.parse(conn)

--- a/tests/unit_test/test_command_server_no_image.py
+++ b/tests/unit_test/test_command_server_no_image.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+import time
+import actfw_core
+import threading
+
+
+def test_command_server_terminate():
+    # try to catch assert error
+    exception = None
+
+    def excepthook(args, /):
+        nonlocal exception
+        exception = args.exc_value
+    threading.excepthook = excepthook
+
+    # Actcast application
+    app = actfw_core.Application()
+
+    # CommandServer (for `Take Photo` command)
+    cmd = actfw_core.CommandServer("/tmp/test.sock")
+    app.register_task(cmd)
+
+
+    # Start application
+    th = threading.Thread(target=lambda: app.run())
+    th.start()
+    # terminate CommandServer task without calling `update_image`
+    time.sleep(0.1)
+    app.stop()
+    th.join()
+    assert exception is None

--- a/tests/unit_test/test_command_server_no_image.py
+++ b/tests/unit_test/test_command_server_no_image.py
@@ -1,16 +1,18 @@
 #!/usr/bin/python3
-import time
-import actfw_core
 import threading
+import time
+
+import actfw_core
 
 
-def test_command_server_terminate():
+def test_command_server_terminate() -> None:
     # try to catch assert error
     exception = None
 
-    def excepthook(args, /):
+    def excepthook(args: threading._ExceptHookArgs) -> None:
         nonlocal exception
         exception = args.exc_value
+
     threading.excepthook = excepthook
 
     # Actcast application
@@ -19,7 +21,6 @@ def test_command_server_terminate():
     # CommandServer (for `Take Photo` command)
     cmd = actfw_core.CommandServer("/tmp/test.sock")
     app.register_task(cmd)
-
 
     # Start application
     th = threading.Thread(target=lambda: app.run())

--- a/tests/unit_test/test_command_server_no_image.py
+++ b/tests/unit_test/test_command_server_no_image.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import threading
 import time
+from typing import Any
 
 import actfw_core
 
@@ -9,7 +10,7 @@ def test_command_server_terminate() -> None:
     # try to catch assert error
     exception = None
 
-    def excepthook(args: threading._ExceptHookArgs) -> None:
+    def excepthook(args: Any) -> None:
         nonlocal exception
         exception = args.exc_value
 


### PR DESCRIPTION

## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary


Fix assertion error when the CommandServer is terminating without calling `cmd.update_image()`.
