### PR TITLE
add functions to get environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## xxxx
 
 - Fix a bug: actfw doesn't raise assertion error when it is stopped before `update_image` is called.
+- Add functions in `actfw_core.system` in order to get environment variables available in the container.
 
 ## 2.2.0a0 (2022-03-14)
 

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -3,27 +3,27 @@ from typing import Optional
 
 def get_actcast_protocol_version() -> str:
     "Protocol version of agent-app communication. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    os.environ.get("ACTCAST_PROTOCOL_VERSION")
+    return os.environ.get("ACTCAST_PROTOCOL_VERSION")
 
 def get_actcast_device_id() -> str:
     "Device ID of the device running the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    os.environ.get("ACTCAST_DEVICE_ID")
+    return os.environ.get("ACTCAST_DEVICE_ID")
 
 def get_actcast_group_id() -> int:
     "Group ID that the device is belonging to. Since ACTCAST_PROTOCOL_VERSION 1.2.0."
-    int(os.environ.get("ACTCAST_GROUP_ID"))
+    return int(os.environ.get("ACTCAST_GROUP_ID"))
 
 def get_actcast_act_id() -> int:
     "Act ID of the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    int(os.environ.get("ACTCAST_ACT_ID"))
+    return int(os.environ.get("ACTCAST_ACT_ID"))
 
 def get_actcast_instance_id() -> str:
     "ID that identifies the launch of the actcast application, like PID. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    os.environ.get("ACTCAST_INSTANCE_ID")
+    return os.environ.get("ACTCAST_INSTANCE_ID")
 
 def get_actcast_device_type() -> str:
     "Device type. Since ACTCAST_PROTOCOL_VERSION 1.1.0."
-    os.environ.get("ACTCAST_DEVICE_TYPE")
+    return os.environ.get("ACTCAST_DEVICE_TYPE")
 
 def get_act_settings_path() -> str:
     """
@@ -32,7 +32,7 @@ def get_act_settings_path() -> str:
     Use get_settings in Application to get act settings.
     Since ACTCAST_PROTOCOL_VERSION 1.0.0.
     """
-    os.environ.get("ACT_SETTINGS_PATH")
+    return os.environ.get("ACT_SETTINGS_PATH")
 
 def get_actcast_command_sock() -> str:
     """
@@ -41,7 +41,7 @@ def get_actcast_command_sock() -> str:
     Use CommandServer to receive commands from actcast agent.
     Since ACTCAST_PROTOCOL_VERSION 1.0.0.
     """
-    os.environ.get("ACTCAST_COMMAND_SOCK")
+    return os.environ.get("ACTCAST_COMMAND_SOCK")
 
 def get_actcast_service_sock() -> str:
     """
@@ -50,17 +50,17 @@ def get_actcast_service_sock() -> str:
     Use ServiceClient to send commands to actcast agent.
     Since ACTCAST_PROTOCOL_VERSION 1.0.0.
     """
-    os.environ.get("ACTCAST_SERVICE_SOCK")
+    return os.environ.get("ACTCAST_SERVICE_SOCK")
 
 def get_actcast_socks_server() -> Optional[str]:
     "URL of SOCKS5 proxy server. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    os.environ.get("ACTCAST_SOCKS_SERVER")
+    return os.environ.get("ACTCAST_SOCKS_SERVER")
 
 def get_actcast_agent_simulator() -> Optional[str]:
     "Fixed value \"actsim\" if on actsim environment. Not set otherwise. Since ACTCAST_PROTOCOL_VERSION 1.1.0."
-    os.environ.get("ACTCAST_AGENT_SIMULATOR")
+    return os.environ.get("ACTCAST_AGENT_SIMULATOR")
 
 def get_actcast_firmware_type() -> str:
     "Firmware type of the host. Since ACTCAST_PROTOCOL_VERSION 1.3.0."
-    os.environ.get("ACTCAST_FIRMWARE_TYPE")
+    return os.environ.get("ACTCAST_FIRMWARE_TYPE")
 

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -1,12 +1,11 @@
 import os
-from typing import Optional
-from typing import cast
+from typing import Optional, cast
 
 
-def _get_env_str(name) -> str:
+def _get_env_str(name: str) -> str:
     return cast(str, os.environ.get(name))
 
-def _get_env_int(name) -> int:
+def _get_env_int(name: str) -> int:
     return int(cast(str, os.environ.get(name)))
 
 def get_actcast_protocol_version() -> str:

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -9,6 +9,7 @@ class EnvironmentVariableNotSet(Exception):
     def __str__(self) -> str:
         return f"Environment variable {self.name} is not set. Perhaps the host agent is too old?"
 
+
 def _get_env_str(name: str) -> str:
     ret = os.environ.get(name)
     if ret is None:

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, cast
+from typing import Optional
 
 
 class EnvironmentVariableNotSet(Exception):

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -1,29 +1,37 @@
 import os
 from typing import Optional
+from typing import cast
+
+
+def _get_env_str(name) -> str:
+    return cast(str, os.environ.get(name))
+
+def _get_env_int(name) -> int:
+    return int(cast(str, os.environ.get(name)))
 
 def get_actcast_protocol_version() -> str:
     "Protocol version of agent-app communication. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    return os.environ.get("ACTCAST_PROTOCOL_VERSION")
+    return _get_env_str("ACTCAST_PROTOCOL_VERSION")
 
 def get_actcast_device_id() -> str:
     "Device ID of the device running the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    return os.environ.get("ACTCAST_DEVICE_ID")
+    return _get_env_str("ACTCAST_DEVICE_ID")
 
 def get_actcast_group_id() -> int:
     "Group ID that the device is belonging to. Since ACTCAST_PROTOCOL_VERSION 1.2.0."
-    return int(os.environ.get("ACTCAST_GROUP_ID"))
+    return _get_env_int("ACTCAST_GROUP_ID")
 
 def get_actcast_act_id() -> int:
     "Act ID of the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    return int(os.environ.get("ACTCAST_ACT_ID"))
+    return _get_env_int("ACTCAST_ACT_ID")
 
 def get_actcast_instance_id() -> str:
     "ID that identifies the launch of the actcast application, like PID. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
-    return os.environ.get("ACTCAST_INSTANCE_ID")
+    return _get_env_str("ACTCAST_INSTANCE_ID")
 
 def get_actcast_device_type() -> str:
     "Device type. Since ACTCAST_PROTOCOL_VERSION 1.1.0."
-    return os.environ.get("ACTCAST_DEVICE_TYPE")
+    return _get_env_str("ACTCAST_DEVICE_TYPE")
 
 def get_act_settings_path() -> str:
     """
@@ -32,7 +40,7 @@ def get_act_settings_path() -> str:
     Use get_settings in Application to get act settings.
     Since ACTCAST_PROTOCOL_VERSION 1.0.0.
     """
-    return os.environ.get("ACT_SETTINGS_PATH")
+    return _get_env_str("ACT_SETTINGS_PATH")
 
 def get_actcast_command_sock() -> str:
     """
@@ -41,7 +49,7 @@ def get_actcast_command_sock() -> str:
     Use CommandServer to receive commands from actcast agent.
     Since ACTCAST_PROTOCOL_VERSION 1.0.0.
     """
-    return os.environ.get("ACTCAST_COMMAND_SOCK")
+    return _get_env_str("ACTCAST_COMMAND_SOCK")
 
 def get_actcast_service_sock() -> str:
     """
@@ -50,7 +58,7 @@ def get_actcast_service_sock() -> str:
     Use ServiceClient to send commands to actcast agent.
     Since ACTCAST_PROTOCOL_VERSION 1.0.0.
     """
-    return os.environ.get("ACTCAST_SERVICE_SOCK")
+    return _get_env_str("ACTCAST_SERVICE_SOCK")
 
 def get_actcast_socks_server() -> Optional[str]:
     "URL of SOCKS5 proxy server. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
@@ -62,5 +70,5 @@ def get_actcast_agent_simulator() -> Optional[str]:
 
 def get_actcast_firmware_type() -> str:
     "Firmware type of the host. Since ACTCAST_PROTOCOL_VERSION 1.3.0."
-    return os.environ.get("ACTCAST_FIRMWARE_TYPE")
+    return _get_env_str("ACTCAST_FIRMWARE_TYPE")
 

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -1,13 +1,25 @@
 import os
 from typing import Optional, cast
 
+class EnvironmentVariableNotSet(Exception):
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return f"Environment variable {name} is not set. Perhaps the host agent is too old?"
 
 def _get_env_str(name: str) -> str:
-    return cast(str, os.environ.get(name))
+    ret = os.environ.get(name)
+    if ret is None:
+        raise EnvironmentVariableNotSet(name)
+    return cast(str, ret)
 
 
 def _get_env_int(name: str) -> int:
-    return int(cast(str, os.environ.get(name)))
+    ret = os.environ.get(name)
+    if ret is None:
+        raise EnvironmentVariableNotSet(name)
+    return int(cast(str, ret))
 
 
 def get_actcast_protocol_version() -> str:

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -1,25 +1,26 @@
 import os
 from typing import Optional, cast
 
+
 class EnvironmentVariableNotSet(Exception):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def __str__(self):
-        return f"Environment variable {name} is not set. Perhaps the host agent is too old?"
+    def __str__(self) -> str:
+        return f"Environment variable {self.name} is not set. Perhaps the host agent is too old?"
 
 def _get_env_str(name: str) -> str:
     ret = os.environ.get(name)
     if ret is None:
         raise EnvironmentVariableNotSet(name)
-    return cast(str, ret)
+    return ret
 
 
 def _get_env_int(name: str) -> int:
     ret = os.environ.get(name)
     if ret is None:
         raise EnvironmentVariableNotSet(name)
-    return int(cast(str, ret))
+    return int(ret)
 
 
 def get_actcast_protocol_version() -> str:

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -5,32 +5,40 @@ from typing import Optional, cast
 def _get_env_str(name: str) -> str:
     return cast(str, os.environ.get(name))
 
+
 def _get_env_int(name: str) -> int:
     return int(cast(str, os.environ.get(name)))
+
 
 def get_actcast_protocol_version() -> str:
     "Protocol version of agent-app communication. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
     return _get_env_str("ACTCAST_PROTOCOL_VERSION")
 
+
 def get_actcast_device_id() -> str:
     "Device ID of the device running the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
     return _get_env_str("ACTCAST_DEVICE_ID")
+
 
 def get_actcast_group_id() -> int:
     "Group ID that the device is belonging to. Since ACTCAST_PROTOCOL_VERSION 1.2.0."
     return _get_env_int("ACTCAST_GROUP_ID")
 
+
 def get_actcast_act_id() -> int:
     "Act ID of the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
     return _get_env_int("ACTCAST_ACT_ID")
+
 
 def get_actcast_instance_id() -> str:
     "ID that identifies the launch of the actcast application, like PID. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
     return _get_env_str("ACTCAST_INSTANCE_ID")
 
+
 def get_actcast_device_type() -> str:
     "Device type. Since ACTCAST_PROTOCOL_VERSION 1.1.0."
     return _get_env_str("ACTCAST_DEVICE_TYPE")
+
 
 def get_act_settings_path() -> str:
     """
@@ -41,6 +49,7 @@ def get_act_settings_path() -> str:
     """
     return _get_env_str("ACT_SETTINGS_PATH")
 
+
 def get_actcast_command_sock() -> str:
     """
     Path of socket file to receive command from actcast agent.
@@ -49,6 +58,7 @@ def get_actcast_command_sock() -> str:
     Since ACTCAST_PROTOCOL_VERSION 1.0.0.
     """
     return _get_env_str("ACTCAST_COMMAND_SOCK")
+
 
 def get_actcast_service_sock() -> str:
     """
@@ -59,15 +69,17 @@ def get_actcast_service_sock() -> str:
     """
     return _get_env_str("ACTCAST_SERVICE_SOCK")
 
+
 def get_actcast_socks_server() -> Optional[str]:
     "URL of SOCKS5 proxy server. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
     return os.environ.get("ACTCAST_SOCKS_SERVER")
 
+
 def get_actcast_agent_simulator() -> Optional[str]:
-    "Fixed value \"actsim\" if on actsim environment. Not set otherwise. Since ACTCAST_PROTOCOL_VERSION 1.1.0."
+    'Fixed value "actsim" if on actsim environment. Not set otherwise. Since ACTCAST_PROTOCOL_VERSION 1.1.0.'
     return os.environ.get("ACTCAST_AGENT_SIMULATOR")
+
 
 def get_actcast_firmware_type() -> str:
     "Firmware type of the host. Since ACTCAST_PROTOCOL_VERSION 1.3.0."
     return _get_env_str("ACTCAST_FIRMWARE_TYPE")
-

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -1,0 +1,66 @@
+import os
+from typing import Optional
+
+def get_actcast_protocol_version() -> str:
+    "Protocol version of agent-app communication. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
+    os.environ.get("ACTCAST_PROTOCOL_VERSION")
+
+def get_actcast_device_id() -> str:
+    "Device ID of the device running the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
+    os.environ.get("ACTCAST_DEVICE_ID")
+
+def get_actcast_group_id() -> int:
+    "Group ID that the device is belonging to. Since ACTCAST_PROTOCOL_VERSION 1.2.0."
+    int(os.environ.get("ACTCAST_GROUP_ID"))
+
+def get_actcast_act_id() -> int:
+    "Act ID of the actcast application. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
+    int(os.environ.get("ACTCAST_ACT_ID"))
+
+def get_actcast_instance_id() -> str:
+    "ID that identifies the launch of the actcast application, like PID. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
+    os.environ.get("ACTCAST_INSTANCE_ID")
+
+def get_actcast_device_type() -> str:
+    "Device type. Since ACTCAST_PROTOCOL_VERSION 1.1.0."
+    os.environ.get("ACTCAST_DEVICE_TYPE")
+
+def get_act_settings_path() -> str:
+    """
+    Path of act settings.
+    This is rather low level API.
+    Use get_settings in Application to get act settings.
+    Since ACTCAST_PROTOCOL_VERSION 1.0.0.
+    """
+    os.environ.get("ACT_SETTINGS_PATH")
+
+def get_actcast_command_sock() -> str:
+    """
+    Path of socket file to receive command from actcast agent.
+    This is rather low level API.
+    Use CommandServer to receive commands from actcast agent.
+    Since ACTCAST_PROTOCOL_VERSION 1.0.0.
+    """
+    os.environ.get("ACTCAST_COMMAND_SOCK")
+
+def get_actcast_service_sock() -> str:
+    """
+    Path of socket file to send command to actcast agent.
+    This is rather low level API.
+    Use ServiceClient to send commands to actcast agent.
+    Since ACTCAST_PROTOCOL_VERSION 1.0.0.
+    """
+    os.environ.get("ACTCAST_SERVICE_SOCK")
+
+def get_actcast_socks_server() -> Optional[str]:
+    "URL of SOCKS5 proxy server. Since ACTCAST_PROTOCOL_VERSION 1.0.0."
+    os.environ.get("ACTCAST_SOCKS_SERVER")
+
+def get_actcast_agent_simulator() -> Optional[str]:
+    "Fixed value \"actsim\" if on actsim environment. Not set otherwise. Since ACTCAST_PROTOCOL_VERSION 1.1.0."
+    os.environ.get("ACTCAST_AGENT_SIMULATOR")
+
+def get_actcast_firmware_type() -> str:
+    "Firmware type of the host. Since ACTCAST_PROTOCOL_VERSION 1.3.0."
+    os.environ.get("ACTCAST_FIRMWARE_TYPE")
+


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

Add functions in `actfw_core.system` in order to get environment variables available in the container. This includes `get_actcast_firmware_type`, which will be provided by future actsim/actcast agent