### PR TITLE
use python 3.10 because 3.11 causes install error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  python-versions: &python-versions ["3.6", "3.7", "3.8", "3.9"]
+  python-versions: &python-versions ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
 commands:
   install-python-dev-tools:
@@ -58,7 +58,7 @@ commands:
 jobs:
   lint:
     docker:
-      - image: python:3-buster
+      - image: python:3.10-buster
         auth: &docker-hub-auth
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -132,7 +132,7 @@ jobs:
 
   build-api-doc:
     docker:
-      - image: python:3-buster
+      - image: python:3.10-buster
         auth: *docker-hub-auth
     steps:
       - checkout
@@ -153,7 +153,7 @@ jobs:
 
   build-package:
     docker:
-      - image: python:3-buster
+      - image: python:3.10-buster
         auth: *docker-hub-auth
     steps:
       - checkout
@@ -216,7 +216,7 @@ jobs:
 
   deploy-package:
     docker:
-      - image: python:3-buster
+      - image: python:3.10-buster
         auth: *docker-hub-auth
     steps:
       - checkout


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary
Use python 3.10 in builds because 3.11 causes some errors.

