### PR TITLE
Find suitable camera devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `find_usb_camera_device` and `find_csi_camera_device` functions to `actfw_core.system`.
+
 ## 2.2.1 (2023-07-13)
 
 - Add retry logic to open v4l2 Video device.

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -236,6 +236,7 @@ def _find_specific_video_device(video_port: VideoPort) -> Optional[str]:
     devs = _list_video_devices()
     for dev in devs:
         try:
+            # No `video.close()` leads to Capture timeout error.
             with Video(dev) as video:
                 if video.query_capability() == video_port:
                     return dev

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from actfw_core.v4l2.video import Video, VideoPort
+from actfw_core.v4l2.video import Video, VideoPort  # type: ignore
 
 
 class EnvironmentVariableNotSet(Exception):
@@ -203,16 +203,14 @@ def _get_camera_device_info(devs: DeviceSupply, default_image_source: Optional[s
                         node.label = "image_source"
                 return info
             else:
-                raise RuntimeError(
-                    f"default_image_source={default_image_source} is not mounted. Fix your manifesto files.")
+                raise RuntimeError(f"default_image_source={default_image_source} is not mounted. Fix your manifesto files.")
         else:
             raise RuntimeError(
                 "Not found image_source. Fix your manifesto files or give default_image_source to get_camera_device_info."
             )
 
     else:
-        raise RuntimeError(
-            "Not found camera device. Fix your manifesto files.")
+        raise RuntimeError("Not found camera device. Fix your manifesto files.")
 
 
 def get_camera_device_info(default_image_source: Optional[str] = None) -> DeviceInfo:

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -1,4 +1,3 @@
-import glob
 import json
 import os
 import warnings

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -225,11 +225,11 @@ def get_camera_device_info(default_image_source: Optional[str] = None) -> Device
     return _get_camera_device_info(devs, default_image_source)
 
 
-def _list_video_devices() -> List[Path]:
+def _list_video_devices() -> List[str]:
     return glob.glob("/dev/video*") + glob.glob("/dev/v4l-subdev*")
 
 
-def find_usb_camera_device() -> Optional[Path]:
+def find_usb_camera_device() -> Optional[str]:
     """
     Path of USB camera device.
     Since ACTCAST_PROTOCOL_VERSION 1.3.0.
@@ -256,7 +256,7 @@ def find_usb_camera_device() -> Optional[Path]:
         raise RuntimeError(f"Unknown firmware type: {firmware_type}")
 
 
-def find_csi_camera_device() -> Optional[Path]:
+def find_csi_camera_device() -> Optional[str]:
     """
     Path of CSI camera device.
     Since ACTCAST_PROTOCOL_VERSION 1.3.0.

--- a/actfw_core/v4l2/video.py
+++ b/actfw_core/v4l2/video.py
@@ -870,10 +870,10 @@ class Video(object):
     def query_capability(self):
         cap = capability()
         result = self._ioctl(_VIDIOC.QUERYCAP, byref(cap))
-        if not (cap.capabilities & _V4L2_CAP_VIDEO_CAPTURE):
-            raise RuntimeError("The device doesn't support the single-planar API through the Video Capture interface.")
-        if not (cap.capabilities & _V4L2_CAP_STREAMING):
-            raise RuntimeError("The device doesn't support the streaming I/O method.")
+        if not (cap.device_caps & _V4L2_CAP_VIDEO_CAPTURE):
+            raise RuntimeError("The device node doesn't support the single-planar API through the Video Capture interface.")
+        if not (cap.device_caps & _V4L2_CAP_STREAMING):
+            raise RuntimeError("The device node doesn't support the streaming I/O method.")
         driver = "".join(map(chr, itertools.takewhile(lambda x: x > 0, cap.driver)))
         if driver == "bm2835 mmal" or driver == "unicam":
             return VideoPort.CSI


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

We added `find_usb_camera_device` and `find_csi_camera_device` in order to find suitable camera device from Actcast apps.

### Motivation

In bullseye, when both CSI camera and USB camera are connected, the device files numbered the following patterns.

- CSI camera: `/dev/video0` (Video Capture) and `/dev/video1` (Video Metadata), USB camera: `/dev/video2` (Video Capture) and `/dev/video3` (Video Metadata)
- USB camera: `/dev/video0` and `/dev/video1`, CSI camera: `/dev/video2` and `/dev/video3`
- CSI camera: `/dev/video0`, USB camera: `/dev/video1` and `/dev/video2`
- USB camera: `/dev/video0` and `/dev/video1`, CSI camera: `/dev/video2`

To make it easier to select the desired camera from Actcast apps, we have implemented the two functions.