### PR TITLE
Fix install-poetry job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,18 @@ commands:
             echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
   install-old-poetry:
+    parameters:
+      poetry-version:
+        type: string
     steps:
       - run:
-          name: Install poetry 1.1
+          name: Install poetry << parameters.poetry-version >>
           command: |
             python3 -m pip install --user pipx
             python3 -m pipx ensurepath
             echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
-            pipx install poetry==1.1.15
+            pipx install poetry==<< parameters.poetry-version >>
   poetry-install:
     steps:
       # See: https://circleci.com/docs/2.0/language-python/#cache-dependencies
@@ -90,11 +93,20 @@ jobs:
           condition:
             equal: ["3.6", << parameters.python-version >> ]
           steps:
-            - install-old-poetry
+            - install-old-poetry:
+                poetry-version: "1.1.15"
+      - when:
+          condition:
+            equal: ["3.7", << parameters.python-version >> ]
+          steps:
+            - install-old-poetry:
+                poetry-version: "1.5.1"
       - when:
           condition:
             not:
-              equal: ["3.6", << parameters.python-version >> ]
+              or:
+                - equal: ["3.6", << parameters.python-version >> ]
+                - equal: ["3.7", << parameters.python-version >> ]
           steps:
             - install-poetry
       - poetry-install
@@ -118,11 +130,20 @@ jobs:
           condition:
             equal: ["3.6", << parameters.python-version >> ]
           steps:
-            - install-old-poetry
+            - install-old-poetry:
+                poetry-version: "1.1.15"
+      - when:
+          condition:
+            equal: ["3.7", << parameters.python-version >> ]
+          steps:
+            - install-old-poetry:
+                poetry-version: "1.5.1"
       - when:
           condition:
             not:
-              equal: ["3.6", << parameters.python-version >> ]
+              or:
+                - equal: ["3.6", << parameters.python-version >> ]
+                - equal: ["3.7", << parameters.python-version >> ]
           steps:
             - install-poetry
       - poetry-install


### PR DESCRIPTION
## Check list

- [ ] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

- Fixed `install-poetry` job
  - In Python 3.7, it is no longer possible to install the latest version of poetry (1.6.1), so we have pinned it to poetry 1.5.1.