### PR TITLE
feat: Add support for application settings from schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `AppSettings` class and `SettingSchema` class to `actfw_core.application`.
+
 ## 2.4.0 (2024-01-23)
 
 - upgrade pillow version for python>=3.11 environment

--- a/actfw_core/application.py
+++ b/actfw_core/application.py
@@ -1,11 +1,77 @@
 import json
 import os
 import signal
+import sys
 import time
 from types import FrameType
 from typing import Any, Dict, Iterable, List, Optional
 
 from actfw_core.task import Task
+
+
+class SettingSchema:
+
+    def __init__(self,
+                 title: str,
+                 description: str,
+                 type_: type,
+                 default: Any = None,
+                 ui_type: str = None):
+        self.title = title
+        self.description = description
+        self.type = type_
+        self.default = default
+        self.ui_type = ui_type
+
+    @staticmethod
+    def decoder(obj):
+        if "title" in obj and "description" in obj and "type" in obj:
+            return SettingSchema(obj["title"], obj["description"],
+                                 SettingSchema.infertype(obj["type"]), obj.get("default", None),
+                                 obj.get("x-ui-type"))
+        return obj
+
+    @staticmethod
+    def infertype(typestring):
+        if typestring == "number": return float
+        elif typestring == "integer": return int
+        elif typestring == "boolean": return bool
+        else: return str
+
+
+class AppSettings:
+
+    def __init__(self, settings: Dict[str, Any], schema: Dict[str, SettingSchema] = {}):
+        self.settings = settings
+        self.schema = schema
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self.settings:
+            if isinstance(self.settings[name], self.schema[name].type):
+                return self.settings[name]
+            elif self.schema[name].default is not None:
+                print(f"Invalid type for setting:{name}. Using schema default value.",
+                      file=sys.stderr,
+                      flush=True)
+                return self.schema[name].default
+            else:
+                print(f"Invalid type of {name}: {type(name)}", file=sys.stderr, flush=True)
+        elif name in self.schema:
+            print(f"Setting:{name} not found. Using schema default value.",
+                  file=sys.stderr,
+                  flush=True)
+            return self.schema[name].default
+        else:
+            raise AttributeError(f"{name} is not found in settings.")
+
+    def __repr__(self) -> str:
+        values = []
+        for key, schema in self.schema.items():
+            if schema.ui_type == "password":
+                values.append(f"{key}=***")
+            else:
+                values.append(f"{key}={getattr(self, key)}")
+        return f"AppSettings({', '.join(values)})"
 
 
 class Application:
@@ -56,6 +122,18 @@ class Application:
         if self.settings is not None:
             settings.update(self.settings)
         return settings
+
+    def get_app_settings(self, path: str = "setting_schema.json") -> AppSettings:
+        """
+        Get application settings from schema.
+        Args:
+            path (str): path to schema file
+        Returns:
+            AppSettings: application settings
+        """
+        with open(path) as f:
+            self.schema = json.load(f, object_hook=SettingSchema.decoder)["properties"]
+        return AppSettings(self.get_settings({}), self.schema)
 
     def register_task(self, task: Task) -> None:
         """

--- a/actfw_core/application.py
+++ b/actfw_core/application.py
@@ -16,7 +16,7 @@ class SettingSchema:
                  description: str,
                  type_: type,
                  default: Any = None,
-                 ui_type: str = None):
+                 ui_type: Optional[str] = None):
         self.title = title
         self.description = description
         self.type = type_

--- a/actfw_core/application.py
+++ b/actfw_core/application.py
@@ -10,7 +10,6 @@ from actfw_core.task import Task
 
 
 class SettingSchema:
-
     def __init__(
         self,
         title: str,
@@ -50,7 +49,6 @@ class SettingSchema:
 
 
 class AppSettings:
-
     def __init__(self, settings: Dict[str, Any], schema: Dict[str, SettingSchema]):
         self.settings = settings
         self.schema = schema
@@ -67,9 +65,7 @@ class AppSettings:
                 )
                 return self.schema[name].default
             else:
-                print(
-                    f"Invalid type of {name}: {type(name)}", file=sys.stderr, flush=True
-                )
+                print(f"Invalid type of {name}: {type(name)}", file=sys.stderr, flush=True)
         elif name in self.schema:
             print(
                 f"Setting:{name} not found. Using schema default value.",

--- a/actfw_core/application.py
+++ b/actfw_core/application.py
@@ -24,7 +24,7 @@ class SettingSchema:
         self.ui_type = ui_type
 
     @staticmethod
-    def decoder(obj):
+    def decoder(obj: Any) -> Any:
         if "title" in obj and "description" in obj and "type" in obj:
             return SettingSchema(obj["title"], obj["description"],
                                  SettingSchema.infertype(obj["type"]), obj.get("default", None),
@@ -32,7 +32,7 @@ class SettingSchema:
         return obj
 
     @staticmethod
-    def infertype(typestring):
+    def infertype(typestring: str) -> type:
         if typestring == "number": return float
         elif typestring == "integer": return int
         elif typestring == "boolean": return bool
@@ -78,12 +78,11 @@ class Application:
     running: bool
     tasks: List[Task]
     settings: Optional[Dict[str, Any]]
-
     """Actcast Application"""
 
     def __init__(
-        self,
-        stop_by_signals: Iterable[signal.Signals] = (signal.SIGINT, signal.SIGTERM),
+            self,
+            stop_by_signals: Iterable[signal.Signals] = (signal.SIGINT, signal.SIGTERM),
     ) -> None:
         self.running = True
         for sig in stop_by_signals:

--- a/actfw_core/application.py
+++ b/actfw_core/application.py
@@ -51,7 +51,7 @@ class SettingSchema:
 
 class AppSettings:
 
-    def __init__(self, settings: Dict[str, Any], schema: Dict[str, SettingSchema] = {}):
+    def __init__(self, settings: Dict[str, Any], schema: Dict[str, SettingSchema]):
         self.settings = settings
         self.schema = schema
 
@@ -94,6 +94,7 @@ class Application:
     running: bool
     tasks: List[Task]
     settings: Optional[Dict[str, Any]]
+
     """Actcast Application"""
 
     def __init__(

--- a/actfw_core/application.py
+++ b/actfw_core/application.py
@@ -11,12 +11,14 @@ from actfw_core.task import Task
 
 class SettingSchema:
 
-    def __init__(self,
-                 title: str,
-                 description: str,
-                 type_: type,
-                 default: Any = None,
-                 ui_type: Optional[str] = None):
+    def __init__(
+        self,
+        title: str,
+        description: str,
+        type_: type,
+        default: Any = None,
+        ui_type: Optional[str] = None,
+    ):
         self.title = title
         self.description = description
         self.type = type_
@@ -26,17 +28,25 @@ class SettingSchema:
     @staticmethod
     def decoder(obj: Any) -> Any:
         if "title" in obj and "description" in obj and "type" in obj:
-            return SettingSchema(obj["title"], obj["description"],
-                                 SettingSchema.infertype(obj["type"]), obj.get("default", None),
-                                 obj.get("x-ui-type"))
+            return SettingSchema(
+                obj["title"],
+                obj["description"],
+                SettingSchema.infertype(obj["type"]),
+                obj.get("default", None),
+                obj.get("x-ui-type"),
+            )
         return obj
 
     @staticmethod
     def infertype(typestring: str) -> type:
-        if typestring == "number": return float
-        elif typestring == "integer": return int
-        elif typestring == "boolean": return bool
-        else: return str
+        if typestring == "number":
+            return float
+        elif typestring == "integer":
+            return int
+        elif typestring == "boolean":
+            return bool
+        else:
+            return str
 
 
 class AppSettings:
@@ -50,16 +60,22 @@ class AppSettings:
             if isinstance(self.settings[name], self.schema[name].type):
                 return self.settings[name]
             elif self.schema[name].default is not None:
-                print(f"Invalid type for setting:{name}. Using schema default value.",
-                      file=sys.stderr,
-                      flush=True)
+                print(
+                    f"Invalid type for setting:{name}. Using schema default value.",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 return self.schema[name].default
             else:
-                print(f"Invalid type of {name}: {type(name)}", file=sys.stderr, flush=True)
+                print(
+                    f"Invalid type of {name}: {type(name)}", file=sys.stderr, flush=True
+                )
         elif name in self.schema:
-            print(f"Setting:{name} not found. Using schema default value.",
-                  file=sys.stderr,
-                  flush=True)
+            print(
+                f"Setting:{name} not found. Using schema default value.",
+                file=sys.stderr,
+                flush=True,
+            )
             return self.schema[name].default
         else:
             raise AttributeError(f"{name} is not found in settings.")
@@ -81,8 +97,8 @@ class Application:
     """Actcast Application"""
 
     def __init__(
-            self,
-            stop_by_signals: Iterable[signal.Signals] = (signal.SIGINT, signal.SIGTERM),
+        self,
+        stop_by_signals: Iterable[signal.Signals] = (signal.SIGINT, signal.SIGTERM),
     ) -> None:
         self.running = True
         for sig in stop_by_signals:


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

The code changes introduce a new class `SettingSchema` and `AppSettings` to handle application settings based on a schema. The `SettingSchema` class defines the structure of a setting, including its title, description, type, default value, and UI type. The `AppSettings` class manages the application settings and provides a way to access the settings based on the schema.

This feature eliminates the need for app authors to double manage setting schema and in-app management.
It also allows the app to add future settings to the app with confidence, as it handles fallback based on the schema appropriately.
For backward compatibility, the methods for obtaining app settings are separated.
To use this method, the location of the setting schema must be placed in the same hierarchy as the main script, and a symbolic link is required to conform to the standard hierarchical structure of the actdk. I personally look forward to future tool support for this part.
