### PR TITLE
Fix: error querying device capabilities from libv4lcontrol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix a bug: query non image_source devices for capabilities.
+
 ## 2.5.0 (2024-08-23)
 
 - Add support for the `imx708_wide` sensor to `UnicamIspCapture`. Note: Autofocus is not supported.

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -227,7 +227,7 @@ def _list_video_devices() -> List[str]:
     cameras = [dev for dev in devs.devices if dev.type == "camera"]
     paths: List[str] = []
     for c in cameras:
-        for node in c.nodes:
+        for node in filter(lambda n: str(n.path).startswith("/dev/video"), c.nodes):
             paths.append(str(node.path))
     return paths
 


### PR DESCRIPTION
fix error:
> libv4lcontrol: error querying device capabilities: Inappropriate ioctl for device

## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary


