### PR TITLE
chore: fix_csi_camera_error_message

### DIFF
--- a/actfw_core/capture.py
+++ b/actfw_core/capture.py
@@ -98,7 +98,7 @@ class V4LCameraCapture(Producer[Frame[bytes]]):
         try:
             firmware_type = get_actcast_firmware_type()
             if firmware_type == "raspberrypi-bullseye" and cap == VideoPort.CSI:
-                raise RuntimeError("CSI camera is not supported in bullseye yet.")
+                raise RuntimeError("CSI camera is not supported in this module. Use UnicamIspCapture instead")
         except EnvironmentVariableNotSet:
             pass
 


### PR DESCRIPTION
## Check list

- [ ] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

- bullseyeでcsiカメラ使用時にV4LCameraCapture使ってると`CSI camera is not supported in bullseye yet`というエラーが出るが、文面からUnicamIspCapture使えばよいというのがわからないので文言を修正したい

