### PR TITLE
support imx708 HDR mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add HDR support for `imx708` sensor to `UnicamIspCapture`.
 
 ## 2.11.0 (2025-03-10)
 


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

Enables the HDR mode of the imx708 sensor via the `V4L2_CID_WIDE_DYNAMIC_RANGE` control.  
In HDR mode, the sensor resolution is limited to `(2304, 1296)`.
