### PR TITLE
Fix LibcameraCapture framerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Change default value of framerate in `LibcameraCapture` to 30 from None.
+
 ## 2.12.3 (2025-05-27)
 
 - Add module comment and assertion to `LibcameraCapture`.

--- a/actfw_core/libcamera_capture.py
+++ b/actfw_core/libcamera_capture.py
@@ -108,7 +108,7 @@ class LibcameraCapture(Producer[Frame[bytes]]):
         pixel_format: libcam.PixelFormat,
         camera_index: int = 0,
         orientation: libcam.Orientation = libcam.Orientation.Rotate0,
-        framerate: Optional[int] = None,
+        framerate: int = 30,
     ) -> None:
         """
         Initialization method for the LibcameraCapture class.
@@ -202,9 +202,8 @@ class LibcameraCapture(Producer[Frame[bytes]]):
                 requests.append(request)
 
             controls = {}
-            if self._framerate is not None:
-                frame_duration_limit = int(1_000_000 / self._framerate)
-                controls[libcam.controls.FrameDurationLimits] = (frame_duration_limit, frame_duration_limit)
+            frame_duration_limit = int(1_000_000 / self._framerate)
+            controls[libcam.controls.FrameDurationLimits] = (frame_duration_limit, frame_duration_limit)
             res = self._camera.start(controls=controls)
             if res is not None and res < 0:
                 raise CameraStartError(res)

--- a/actfw_core/libcamera_capture.py
+++ b/actfw_core/libcamera_capture.py
@@ -100,7 +100,7 @@ class LibcameraCapture(Producer[Frame[bytes]]):
     _camera: libcam.Camera
     _requests: Optional[List[libcam.Request]]
     _camera_config: libcam.CameraConfiguration
-    _framerate: Optional[int]
+    _framerate: int
 
     def __init__(
         self,


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary
`LibcameraCapture` で `framerate` が指定されていない場合は `30` をデフォルト値として利用するように変更する。

