### PR TITLE
Feature/libcamera pi5 csi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Add `find_csi_camera_index()` to `libcamera_capture`. On Raspberry Pi 5, libcamera may also enumerate a USB (UVC) camera, so the default `LibcameraCapture(camera_index=0)` could pick the wrong one when both a CSI and a USB camera are connected. `find_csi_camera_index()` returns the index of the CSI camera (identified by its `platform/` id prefix; the location property is not usable for this since CSI cameras report `Location = External`), which can be passed as `LibcameraCapture(..., camera_index=...)`.
-- Recognize the Raspberry Pi 5 CSI receiver driver (`rp1-cfe`) as a CSI camera in `find_csi_camera_device()`, so it returns the CSI device node (instead of `None`) on Raspberry Pi 5 when a CSI camera is connected. Note that on Raspberry Pi 5 this node is a raw CFE node used for presence detection; capture should go through `LibcameraCapture`.
+- Add `find_csi_camera_index()` and support for using CSI cameras on Raspberry Pi 5.
 
 ## 2.17.0 (2026-06-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `find_csi_camera_index()` to `libcamera_capture`. On Raspberry Pi 5, libcamera may also enumerate a USB (UVC) camera, so the default `LibcameraCapture(camera_index=0)` could pick the wrong one when both a CSI and a USB camera are connected. `find_csi_camera_index()` returns the index of the CSI camera (identified by its `platform/` id prefix; the location property is not usable for this since CSI cameras report `Location = External`), which can be passed as `LibcameraCapture(..., camera_index=...)`.
 - Recognize the Raspberry Pi 5 CSI receiver driver (`rp1-cfe`) as a CSI camera in `find_csi_camera_device()`, so it returns the CSI device node (instead of `None`) on Raspberry Pi 5 when a CSI camera is connected. Note that on Raspberry Pi 5 this node is a raw CFE node used for presence detection; capture should go through `LibcameraCapture`.
 
 ## 2.17.0 (2026-06-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Recognize the Raspberry Pi 5 CSI receiver driver (`rp1-cfe`) as a CSI camera in `find_csi_camera_device()`, so it returns the CSI device node (instead of `None`) on Raspberry Pi 5 when a CSI camera is connected. Note that on Raspberry Pi 5 this node is a raw CFE node used for presence detection; capture should go through `LibcameraCapture`.
+
 ## 2.17.0 (2026-06-02)
 
 - Add `CUSTOM_COMMAND` feature to `CommandServer`

--- a/actfw_core/libcamera_capture.py
+++ b/actfw_core/libcamera_capture.py
@@ -94,6 +94,26 @@ class CaptureTimeoutError(Exception):
         return f"{self._msg}: {self._timeout}"
 
 
+def find_csi_camera_index() -> Optional[int]:
+    """Return the index of the first CSI camera, or None if there is none. (Raspberry Pi specific.)
+
+    Intended for selecting a single CSI camera. A CSI camera is identified by its ``platform/`` id
+    prefix (set by the ``rpi/pisp`` / ``rpi/vc4`` pipeline handler); the location property cannot be
+    used since Raspberry Pi CSI cameras report ``Location = External`` just like USB ones. Pass the
+    result to ``LibcameraCapture(..., camera_index=...)`` to avoid accidentally picking a USB camera
+    that libcamera may also enumerate.
+
+    Note:
+        The returned index is not a stable id; it is a position in the libcamera enumeration order
+        and may differ between runs, so use it promptly rather than persisting it.
+    """
+    cm = libcam.CameraManager.singleton()
+    for index, camera in enumerate(cm.cameras):
+        if str(camera.id).startswith("platform/"):
+            return index
+    return None
+
+
 class LibcameraCapture(Producer[Frame[bytes]]):
     _cm: libcam.CameraManager
     _size: Tuple[int, int]
@@ -121,6 +141,7 @@ class LibcameraCapture(Producer[Frame[bytes]]):
             pixel_format: The pixel format. Only RGB888 or BGR888 are supported.
                 cf. https://libcamera.org/api-html/classlibcamera_1_1PixelFormat.html
             camera_index: The index of the camera to use. Defaults to 0.
+                See ``find_csi_camera_index()`` to select the CSI camera when a USB camera is also connected.
             orientation: The orientation of the camera. Defaults to Rotate0.
                 cf. https://libcamera.org/api-html/namespacelibcamera.html#a80ea01625b93ecfe879249ac60c79384.
             framerate: The framerate (fps). If not specified, the default setting of the libcamera is used.

--- a/actfw_core/system.py
+++ b/actfw_core/system.py
@@ -255,7 +255,14 @@ def find_usb_camera_device() -> Optional[str]:
 
 def find_csi_camera_device() -> Optional[str]:
     """
-    Path of CSI camera device.
+    Path of CSI camera device, or None if no CSI camera is connected.
     Since ACTCAST_PROTOCOL_VERSION 1.3.0.
+
+    Note:
+        On Raspberry Pi 5, the returned path is an ``rp1-cfe`` (RP1 Camera Front End) node, which is a
+        raw CSI-2 receiver configured through libcamera's Media Controller pipeline. It is suitable for
+        checking CSI camera presence and for the V4L-based capture path on older devices, but on
+        Raspberry Pi 5 the capture itself should go through ``LibcameraCapture`` (which selects a camera
+        by index, not by this V4L2 node). See ``actfw_core.libcamera_capture.find_csi_camera_index``.
     """
     return _find_specific_video_device(VideoPort.CSI)

--- a/actfw_core/v4l2/video.py
+++ b/actfw_core/v4l2/video.py
@@ -885,7 +885,10 @@ class Video(object):
         if not (cap.device_caps & _V4L2_CAP_STREAMING):
             raise RuntimeError("The device node doesn't support the streaming I/O method.")
         driver = "".join(map(chr, itertools.takewhile(lambda x: x > 0, cap.driver)))
-        if driver == "bm2835 mmal" or driver == "unicam":
+        # "bm2835 mmal": legacy firmware camera stack (Raspberry Pi OS Buster and earlier)
+        # "unicam": BCM2835 Unicam CSI-2 receiver (Raspberry Pi 0-4)
+        # "rp1-cfe": RP1 Camera Front End CSI-2 receiver (Raspberry Pi 5)
+        if driver in ("bm2835 mmal", "unicam", "rp1-cfe"):
             return VideoPort.CSI
         elif driver[: len("uvcvideo")] == "uvcvideo":
             return VideoPort.USB


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

Make CSI camera detection and selection work on Raspberry Pi 5, where the camera stack differs from older devices. Two independent commits:

### 1. Recognize `rp1-cfe` as a CSI camera (`find_csi_camera_device`)

`Video.query_capability()` identifies CSI cameras by the V4L2 driver name, which only matched `bm2835 mmal` (legacy firmware stack) and `unicam` (Pi 0-4). On Raspberry Pi 5 the CSI front-end is the RP1 Camera Front End whose driver is `rp1-cfe`, so `find_csi_camera_device()` fell through to the "unknown driver" path and returned `None` even when a CSI camera was connected. Recognize `rp1-cfe` as a CSI driver.

Verified on a Pi 5: `find_csi_camera_device()` now returns the CSI node (`/dev/video0`) instead of `None`; the USB camera is still detected separately by `find_usb_camera_device()`.

Note: on Pi 5 the returned node is a raw CFE node suitable for presence detection; the capture itself should go through `LibcameraCapture`. The docstring documents this.

### 2. Add `find_csi_camera_index()` (`libcamera_capture`)

On Pi 5, libcamera's UVC pipeline handler may also enumerate a USB (UVC) camera, so the default `LibcameraCapture(camera_index=0)` can pick the wrong one when both a CSI and a USB camera are connected. `find_csi_camera_index()` returns the index of the CSI camera, identified by its `platform/` id prefix.

The camera location property is intentionally not used: on Raspberry Pi, CSI cameras report `Location = External` just like USB cameras, so it does not distinguish them. The `platform/` id prefix (set by the `rpi/pisp` / `rpi/vc4` pipeline handler) does.

Usage:

```python
camera_index = find_csi_camera_index()
if camera_index is None:
    raise RuntimeError("CSI camera not found")
cap = LibcameraCapture(size, pixel_format, camera_index=camera_index)
```

The returned index is a position in the libcamera enumeration order (not a stable id), so it is meant to be used promptly to construct a `LibcameraCapture`. This helper targets the single-CSI-camera case; multi-camera apps should enumerate `cameras()` and select by id themselves.

## Notes

- No API is removed or changed; both are additive.
- The two commits are independent and could be reviewed separately.
