### PR TITLE
bump 2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.18.0 (2026-06-25)
+
 - Add `find_csi_camera_index()` and support for using CSI cameras on Raspberry Pi 5.
 - Add `depad` option to `LibcameraCapture` to enable or disable stripping per-line stride padding.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 name = "actfw-core"
 readme = "README.md"
 repository = "https://github.com/Idein/actfw-core"
-version = "2.17.0"
+version = "2.18.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.12"


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary

- Add `find_csi_camera_index()` and support for using CSI cameras on Raspberry Pi 5.
- Add `depad` option to `LibcameraCapture` to enable or disable stripping per-line stride padding.